### PR TITLE
Add a missing slash to the '../libssh-*' part

### DIFF
--- a/docs/HowTo/vagrant-with-libvirt.md
+++ b/docs/HowTo/vagrant-with-libvirt.md
@@ -73,7 +73,7 @@ rpm2cpio libssh*.src.rpm | cpio -idmv
 tar xf libssh*.tar.xz
 mkdir build
 cd build
-cmake ../libssh-* -DOPENSSL_ROOT_DIR=/opt/vagrant/embedded/
+cmake ../libssh-*/ -DOPENSSL_ROOT_DIR=/opt/vagrant/embedded/
 make
 sudo cp lib/libssh* /opt/vagrant/embedded/lib64
 cd


### PR DESCRIPTION
In some scenarios the `../libssh-*` part expands improperly and prevents cmake from recognizing the expansion as just a directory. A slash at the end should fix it.